### PR TITLE
feat(ansi): implement ansi-correct colors

### DIFF
--- a/dist/catppuccin-frappe.toml
+++ b/dist/catppuccin-frappe.toml
@@ -7,18 +7,18 @@ ansi = [
   '#8caaee',
   '#f4b8e4',
   '#81c8be',
-  '#b5bfe2',
+  '#a5adce',
 ]
 background = '#303446'
 brights = [
   '#626880',
-  '#e78284',
-  '#a6d189',
-  '#e5c890',
-  '#8caaee',
-  '#f4b8e4',
-  '#81c8be',
-  '#a5adce',
+  '#e67172',
+  '#8ec772',
+  '#d9ba73',
+  '#7b9ef0',
+  '#f2a4db',
+  '#5abfb5',
+  '#b5bfe2',
 ]
 compose_cursor = '#eebebe'
 cursor_bg = '#f2d5cf'
@@ -30,6 +30,8 @@ selection_bg = '#626880'
 selection_fg = '#c6d0f5'
 split = '#737994'
 visual_bell = '#414559'
+bold = '#b5bfe2'
+hyperlink = '#8caaee'
 
 [colors.indexed]
 16 = '#ef9f76'

--- a/dist/catppuccin-latte.toml
+++ b/dist/catppuccin-latte.toml
@@ -1,24 +1,24 @@
 [colors]
 ansi = [
-  '#bcc0cc',
+  '#5c5f77',
   '#d20f39',
   '#40a02b',
   '#df8e1d',
   '#1e66f5',
   '#ea76cb',
   '#179299',
-  '#5c5f77',
+  '#acb0be',
 ]
 background = '#eff1f5'
 brights = [
-  '#acb0be',
-  '#d20f39',
-  '#40a02b',
-  '#df8e1d',
-  '#1e66f5',
-  '#ea76cb',
-  '#179299',
   '#6c6f85',
+  '#de293e',
+  '#49af3d',
+  '#eea02d',
+  '#456eff',
+  '#fe85d8',
+  '#2d9fa8',
+  '#bcc0cc',
 ]
 compose_cursor = '#dd7878'
 cursor_bg = '#dc8a78'
@@ -30,6 +30,8 @@ selection_bg = '#acb0be'
 selection_fg = '#4c4f69'
 split = '#9ca0b0'
 visual_bell = '#ccd0da'
+bold = '#bcc0cc'
+hyperlink = '#1e66f5'
 
 [colors.indexed]
 16 = '#fe640b'

--- a/dist/catppuccin-macchiato.toml
+++ b/dist/catppuccin-macchiato.toml
@@ -7,18 +7,18 @@ ansi = [
   '#8aadf4',
   '#f5bde6',
   '#8bd5ca',
-  '#b8c0e0',
+  '#a5adcb',
 ]
 background = '#24273a'
 brights = [
   '#5b6078',
-  '#ed8796',
-  '#a6da95',
-  '#eed49f',
-  '#8aadf4',
-  '#f5bde6',
-  '#8bd5ca',
-  '#a5adcb',
+  '#ec7486',
+  '#8ccf7f',
+  '#e1c682',
+  '#78a1f6',
+  '#f2a9dd',
+  '#63cbc0',
+  '#b8c0e0',
 ]
 compose_cursor = '#f0c6c6'
 cursor_bg = '#f4dbd6'
@@ -30,6 +30,8 @@ selection_bg = '#5b6078'
 selection_fg = '#cad3f5'
 split = '#6e738d'
 visual_bell = '#363a4f'
+bold = '#b8c0e0'
+hyperlink = '#8aadf4'
 
 [colors.indexed]
 16 = '#f5a97f'

--- a/dist/catppuccin-mocha.toml
+++ b/dist/catppuccin-mocha.toml
@@ -7,18 +7,18 @@ ansi = [
   '#89b4fa',
   '#f5c2e7',
   '#94e2d5',
-  '#bac2de',
+  '#a6adc8',
 ]
 background = '#1e1e2e'
 brights = [
   '#585b70',
-  '#f38ba8',
-  '#a6e3a1',
-  '#f9e2af',
-  '#89b4fa',
-  '#f5c2e7',
-  '#94e2d5',
-  '#a6adc8',
+  '#f37799',
+  '#89d88b',
+  '#ebd391',
+  '#74a8fc',
+  '#f2aede',
+  '#6bd7ca',
+  '#bac2de',
 ]
 compose_cursor = '#f2cdcd'
 cursor_bg = '#f5e0dc'
@@ -30,6 +30,8 @@ selection_bg = '#585b70'
 selection_fg = '#cdd6f4'
 split = '#6c7086'
 visual_bell = '#313244'
+bold = '#bac2de'
+hyperlink = '#89b4fa'
 
 [colors.indexed]
 16 = '#fab387'


### PR DESCRIPTION
- Use the ansi-correct colors from the catppuccin style guides.
    Fixes the issue mentioned here: https://github.com/catppuccin/catppuccin/issues/1961

- Add color definitions for bold and hyperlink text.